### PR TITLE
Limit the total of transaction

### DIFF
--- a/common/constant.go
+++ b/common/constant.go
@@ -3,6 +3,8 @@ package common
 const (
 	// AddressZero some transactions do not have To address, use this address instead
 	AddressZero = "0x0000000000000000000000000000000000000000"
+	// NumMaxTransaction if number of transaction is more than this, just return +100000 to the client
+	NumMaxTransaction = 100000
 	// DefaultCleanInterval In minute
 	DefaultCleanInterval = 5
 	// DefaultBlockTTL In hour

--- a/common/constant.go
+++ b/common/constant.go
@@ -4,7 +4,7 @@ const (
 	// AddressZero some transactions do not have To address, use this address instead
 	AddressZero = "0x0000000000000000000000000000000000000000"
 	// NumMaxTransaction if number of transaction is more than this, just return +100000 to the client
-	NumMaxTransaction = 100000
+	NumMaxTransaction = 10000
 	// DefaultCleanInterval In minute
 	DefaultCleanInterval = 5
 	// DefaultBlockTTL In hour

--- a/common/constant.go
+++ b/common/constant.go
@@ -3,7 +3,7 @@ package common
 const (
 	// AddressZero some transactions do not have To address, use this address instead
 	AddressZero = "0x0000000000000000000000000000000000000000"
-	// NumMaxTransaction if number of transaction is more than this, just return +100000 to the client
+	// NumMaxTransaction if number of transaction is more than this, just return +10000 to the client
 	NumMaxTransaction = 10000
 	// DefaultCleanInterval In minute
 	DefaultCleanInterval = 5

--- a/http/server.go
+++ b/http/server.go
@@ -133,9 +133,14 @@ func (server Server) getTransactionsByAccount(c *gin.Context) {
 		}
 		addresses = append(addresses, addr)
 	}
+	totalStr := strconv.Itoa(total)
+	if total > common.NumMaxTransaction {
+		// If this address has a lot of transactions, just say +100000
+		totalStr = "+" + totalStr
+	}
 	// response automatically marshalled using json.Marshall()
 	response := httpTypes.EITransactionsByAccount{
-		Total:   total,
+		Total:   totalStr,
 		Start:   start,
 		Indexes: addresses,
 	}

--- a/http/server.go
+++ b/http/server.go
@@ -135,8 +135,8 @@ func (server Server) getTransactionsByAccount(c *gin.Context) {
 	}
 	totalStr := strconv.Itoa(total)
 	if total > common.NumMaxTransaction {
-		// If this address has a lot of transactions, just say +100000
-		totalStr = "+" + totalStr
+		// If this address has a lot of transactions, just say +10000
+		totalStr = "+" + strconv.Itoa(common.NumMaxTransaction)
 	}
 	// response automatically marshalled using json.Marshall()
 	response := httpTypes.EITransactionsByAccount{

--- a/http/types/response.go
+++ b/http/types/response.go
@@ -11,7 +11,7 @@ import (
 
 // EITransactionsByAccount response for getTransactionsByAccount api
 type EITransactionsByAccount struct {
-	Total   int         `json:"numFound"`
+	Total   string      `json:"numFound"`
 	Start   int         `json:"start"`
 	Indexes []EIAddress `json:"data"`
 }

--- a/http/types/response_test.go
+++ b/http/types/response_test.go
@@ -29,7 +29,7 @@ func TestMarshall(t *testing.T) {
 	idx := AddressToEIAddress(index)
 	idx.Data = []byte{1, 2}
 	response := EITransactionsByAccount{
-		Total:   10,
+		Total:   "10",
 		Start:   5,
 		Indexes: []EIAddress{idx},
 	}
@@ -39,6 +39,6 @@ func TestMarshall(t *testing.T) {
 	dataStr := string(data)
 	log.Printf("%v \n", dataStr)
 	tm := common.UnmarshallIntToTime(big.NewInt(1546848896)).Format(time.RFC3339)
-	expectedStr := fmt.Sprintf(`{"numFound":10,"start":5,"data":[{"address":"from1","txHash":"0xtx1","value":-111,"time":"%v","coupleAddress":"to1","data":"AQI=","gas":0,"gasPrice":null}]}`, tm)
+	expectedStr := fmt.Sprintf(`{"numFound":"10","start":5,"data":[{"address":"from1","txHash":"0xtx1","value":-111,"time":"%v","coupleAddress":"to1","data":"AQI=","gas":0,"gasPrice":null}]}`, tm)
 	assert.Equal(t, expectedStr, dataStr)
 }


### PR DESCRIPTION
Looping thru LevelDB just to know the total of transaction is a PITA, hence limit it to 10000, will consider to reduce it if needed