### PR TITLE
Revert "Retry fetching a block when cannot get transaction receipt"

### DIFF
--- a/indexer/indexer.go
+++ b/indexer/indexer.go
@@ -165,9 +165,8 @@ func (indexer *Indexer) realtimeIndex() {
 			break
 		}
 		log.Printf("Indexer: realtimeIndex - received BlockDetail %v blockTime: %v\n", blockDetail.BlockNumber.String(), common.UnmarshallIntToTime(blockDetail.Time))
-		go func(blockDetail *types.BLockDetail) {
-			indexer.processRealtimeBlock(blockDetail)
-		}(blockDetail)
+		isBatch := false
+		indexer.ProcessBlock(blockDetail, isBatch)
 	}
 	indexer.realtimeFetcher = nil
 	log.Println("Indexer: Stopped realtimeIndex")
@@ -185,8 +184,7 @@ func (indexer *Indexer) batchIndex(batch types.BatchStatus, stop chan struct{}, 
 	i := 0
 	for !batch.IsDone() {
 		blockNumber := batch.Next()
-		isRecpRelax := false
-		blockDetail, err := fetcher.FetchABlock(blockNumber, isRecpRelax)
+		blockDetail, err := fetcher.FetchABlock(blockNumber)
 		if err != nil {
 			// Finish the go-routines, someone will restart index()
 			log.Println(tag + " Indexer: cannot get block " + blockNumber.String() + " , error is " + err.Error())
@@ -217,33 +215,6 @@ func (indexer *Indexer) batchIndex(batch types.BatchStatus, stop chan struct{}, 
 	log.Println(tag + " Indexer: batchIndex is done in " + s + " minutes")
 }
 
-func (indexer *Indexer) processRealtimeBlock(blockDetail *types.BLockDetail) {
-	isRecpRelax := true
-	isBatch := false
-	if !isMissingRecp(blockDetail) {
-		indexer.ProcessBlock(blockDetail, isBatch)
-		return
-	}
-	block := blockDetail
-	blockNumber := block.BlockNumber
-	for i := 0; i < 3; i++ {
-		log.Printf("Waiting for 1 more minute to get receipts for block %v . Try %v \n", blockNumber.String(), i)
-		time.Sleep(1 * time.Minute)
-		block, err := indexer.realtimeFetcher.FetchABlock(blockNumber, isRecpRelax)
-		if err != nil {
-			log.Fatalf("Cannot fetch block %v, error: %v \n", blockNumber.String(), err.Error())
-		}
-		if !isMissingRecp(block) {
-			break
-		}
-	}
-	if !isMissingRecp(block) {
-		indexer.ProcessBlock(block, isBatch)
-		return
-	}
-	log.Fatalln("Cannot get receipts for block " + blockNumber.String())
-}
-
 // ProcessBlock transform blockchain data to our index structure and save it to repo
 func (indexer *Indexer) ProcessBlock(blockDetail *types.BLockDetail, isBatch bool) error {
 	addressIndex, blockIndex := indexer.CreateIndexData(blockDetail)
@@ -254,8 +225,7 @@ func (indexer *Indexer) ProcessBlock(blockDetail *types.BLockDetail, isBatch boo
 func (indexer *Indexer) FetchAndProcess(blockNumber *big.Int) error {
 	indexer.createRealtimeFetcher()
 	log.Printf("Indexer: Fetching block %v", blockNumber)
-	isRecpRelax := false
-	blockDetail, err := indexer.realtimeFetcher.FetchABlock(blockNumber, isRecpRelax)
+	blockDetail, err := indexer.realtimeFetcher.FetchABlock(blockNumber)
 	if err != nil {
 		return err
 	}
@@ -369,15 +339,4 @@ func (indexer *Indexer) createRealtimeFetcher() {
 		return
 	}
 	indexer.realtimeFetcher = fe
-}
-
-func isMissingRecp(blockDetail *types.BLockDetail) bool {
-	transactions := blockDetail.Transactions
-	for _, tx := range transactions {
-		if tx.From == "" && tx.To == "" {
-			log.Printf("Indexer: block %v has traansaction %v without receipt \n", blockDetail.BlockNumber.String(), tx.TxHash)
-			return true
-		}
-	}
-	return false
 }

--- a/indexer/indexer_test.go
+++ b/indexer/indexer_test.go
@@ -181,18 +181,6 @@ func TestWatchAfterBatch(t *testing.T) {
 	// TODO
 }
 
-func TestIsMissingRecp(t *testing.T) {
-	blockDetail := &types.BLockDetail{
-		BlockNumber: big.NewInt(2019),
-		Transactions: []types.TransactionDetail{
-			types.TransactionDetail{From: "", To: "", TxHash: "TestTxHash"},
-		},
-	}
-	assert.True(t, isMissingRecp(blockDetail))
-	blockDetail.Transactions[0].From = "from"
-	assert.False(t, isMissingRecp(blockDetail))
-}
-
 func NewTestIndexer() Indexer {
 	addressDB := memdb.New(comparer.DefaultComparer, 0)
 	addressDAO := dao.NewMemDbDAO(addressDB)

--- a/test/int/indexer_int_test.go
+++ b/test/int/indexer_int_test.go
@@ -32,7 +32,7 @@ func TestContractCreation(t *testing.T) {
 	assert.Nil(t, err)
 	blockNumber := big.NewInt(6808718)
 	// Run Test
-	blockDetail, err := fetcher.FetchABlock(blockNumber, false)
+	blockDetail, err := fetcher.FetchABlock(blockNumber)
 	assert.Nil(t, err)
 	// log.Println(blockDetail)
 	idx := NewTestIndexer()
@@ -60,7 +60,7 @@ func TestFailedTransaction(t *testing.T) {
 	assert.Nil(t, err)
 	blockNumber := big.NewInt(7156456)
 	// This block has 162 transactions but 3 failed
-	blockDetail, err := fetcher.FetchABlock(blockNumber, false)
+	blockDetail, err := fetcher.FetchABlock(blockNumber)
 	assert.Nil(t, err)
 	numSuccess := 0
 	for _, tx := range blockDetail.Transactions {


### PR DESCRIPTION

This reverts commit 9008f26eab098bc96ad1f22e736cb0ff45d43614.

The rerun does not work because "not found" issue happens again when we run batch. Something wrong with 0x01fc989d7ac9ba1610f9a5a32616ac314b2caa094843f85861d978c2b16f1f00 transaction

Get this issue in mainnet2 after we apply the fix:
```
2019/03/04 08:41:45 ChainFetch: RealtimeFetch Waiting for new block hearders...
2019/03/04 08:41:47 Indexer: realtimeIndex - received BlockDetail 7301930 blockTime: 2019-03-04 08:41:39 +0000 UTC
2019/03/04 08:41:47 ChainFetch: getTransactionDetail warning - cannot get receipt for transaction 0x01fc989d7ac9ba1610f9a5a32616ac314b2caa094843f85861d978c2b16f1f00, block 0x71015657cf3a51099d503b2ba14ae4a0f5480d108e732890b987bfcda94dd148, error=not found
2019/03/04 08:41:47 7290108-7301930-: Indexer: cannot get block 7290109 , error is ChainFetch: getTransactionDetail warning - cannot get receipt for transaction 0x01fc989d7ac9ba1610f9a5a32616ac314b2caa094843f85861d978c2b16f1f00, block 0x71015657cf3a51099d503b2ba14ae4a0f5480d108e732890b987bfcda94dd148, error=not found
2019/03/04 08:41:47 7290108-7301930-: Indexer: batchIndex is done in 0.024174 minutes
2019/03/04 08:41:47 IpcManager: Cannot switch IPC, number of IPC = 1
```