### PR TITLE
Fix pointer changed in realtime fetch

### DIFF
--- a/fetcher/fetch.go
+++ b/fetcher/fetch.go
@@ -32,7 +32,7 @@ type EthClient interface {
 // Fetch the interface to interact with blockchain
 type Fetch interface {
 	RealtimeFetch(ch chan<- *types.BLockDetail)
-	FetchABlock(blockNumber *big.Int) (*types.BLockDetail, error)
+	FetchABlock(blockNumber int64) (*types.BLockDetail, error)
 	GetLatestBlock() (*big.Int, error)
 	TransactionByHash(txHash string) (*types.TransactionExtra, error)
 }
@@ -99,7 +99,7 @@ func (cf *ChainFetch) RealtimeFetch(ch chan<- *types.BLockDetail) {
 			break
 		}
 		blockNumber := receivedHeader.Number
-		blockDetail, err := cf.FetchABlock(blockNumber)
+		blockDetail, err := cf.FetchABlock(blockNumber.Int64())
 		if err == nil {
 			ch <- blockDetail
 		} else {
@@ -113,8 +113,10 @@ func (cf *ChainFetch) RealtimeFetch(ch chan<- *types.BLockDetail) {
 }
 
 // FetchABlock fetch a block by block number
-func (cf *ChainFetch) FetchABlock(blockNumber *big.Int) (*types.BLockDetail, error) {
+// Should not use param as pointer because it maybe changed
+func (cf *ChainFetch) FetchABlock(blockNbr int64) (*types.BLockDetail, error) {
 	ctx := context.Background()
+	blockNumber := big.NewInt(blockNbr)
 	block, err := cf.Client.BlockByNumber(ctx, blockNumber)
 	if err != nil {
 		log.Println("ChainFetch: FetchABlock BlockByNumber returns error " + err.Error())

--- a/indexer/indexer.go
+++ b/indexer/indexer.go
@@ -184,7 +184,7 @@ func (indexer *Indexer) batchIndex(batch types.BatchStatus, stop chan struct{}, 
 	i := 0
 	for !batch.IsDone() {
 		blockNumber := batch.Next()
-		blockDetail, err := fetcher.FetchABlock(blockNumber)
+		blockDetail, err := fetcher.FetchABlock(blockNumber.Int64())
 		if err != nil {
 			// Finish the go-routines, someone will restart index()
 			log.Println(tag + " Indexer: cannot get block " + blockNumber.String() + " , error is " + err.Error())
@@ -225,7 +225,7 @@ func (indexer *Indexer) ProcessBlock(blockDetail *types.BLockDetail, isBatch boo
 func (indexer *Indexer) FetchAndProcess(blockNumber *big.Int) error {
 	indexer.createRealtimeFetcher()
 	log.Printf("Indexer: Fetching block %v", blockNumber)
-	blockDetail, err := indexer.realtimeFetcher.FetchABlock(blockNumber)
+	blockDetail, err := indexer.realtimeFetcher.FetchABlock(blockNumber.Int64())
 	if err != nil {
 		return err
 	}

--- a/test/int/indexer_int_test.go
+++ b/test/int/indexer_int_test.go
@@ -32,7 +32,7 @@ func TestContractCreation(t *testing.T) {
 	assert.Nil(t, err)
 	blockNumber := big.NewInt(6808718)
 	// Run Test
-	blockDetail, err := fetcher.FetchABlock(blockNumber)
+	blockDetail, err := fetcher.FetchABlock(blockNumber.Int64())
 	assert.Nil(t, err)
 	// log.Println(blockDetail)
 	idx := NewTestIndexer()
@@ -60,7 +60,7 @@ func TestFailedTransaction(t *testing.T) {
 	assert.Nil(t, err)
 	blockNumber := big.NewInt(7156456)
 	// This block has 162 transactions but 3 failed
-	blockDetail, err := fetcher.FetchABlock(blockNumber)
+	blockDetail, err := fetcher.FetchABlock(blockNumber.Int64())
 	assert.Nil(t, err)
 	numSuccess := 0
 	for _, tx := range blockDetail.Transactions {


### PR DESCRIPTION
## Goal
+ Fix issue in #24 :
```
New log:

2019/03/09 09:13:32 Indexer: realtimeIndex - received BlockDetail 7334145 blockTime: 2019-03-09 09:13:08 +0000 UTC
2019/03/09 09:13:44 ChainFetch: getTransactionDetail cannot get receipt for transaction 0x69bf268e6a9e6f742bdf69c289ee14715df19cbaf90e5711cabf37956814632e, error=not found
2019/03/09 09:13:44 ChainFetch: RealtimeFetch Cannot get block detail for block 7334146
2019/03/09 09:13:44 ChainFetch: Stopped RealtimeFetch
2019/03/09 09:13:44 IpcManager: Cannot switch IPC, number of IPC = 1
2019/03/09 09:13:44 Indexer: Stopping realtimeIndex, ipc is switched?
2019/03/09 09:13:44 Indexer: Stopped realtimeIndex
From etherscan, transaction 0x69bf268e6a9e6f742bdf69c289ee14715df19cbaf90e5711cabf37956814632e belongs to block
7334147 not 7334146
```