### PR TITLE
Another way to make goroutine inside for loop

### DIFF
--- a/fetcher/fetch.go
+++ b/fetcher/fetch.go
@@ -135,7 +135,9 @@ func (cf *ChainFetch) FetchABlock(blockNbr int64) (*types.BLockDetail, error) {
 		for index, tx := range allTransactions {
 			_index, _tx := index, *tx
 			_blockHash := block.Hash()
-			go cf.getTransactionDetail(&wg, _index, _tx, _blockHash, txDetails, errs)
+			go func(index int, tx gethtypes.Transaction, blockHash gethcommon.Hash) {
+				cf.getTransactionDetail(&wg, index, tx, blockHash, txDetails, errs)
+			}(_index, _tx, _blockHash)
 		}
 		wg.Wait()
 	}


### PR DESCRIPTION
## Goal
+ A candidate to fix #24 
## Log
```
2019/03/10 09:19:20 Cleaner: Clean Block DB at 2019-03-10 09:19:20.985144459 +0000 UTC m=+9600.134157115
2019/03/10 09:19:20 Cleaner: deleted 0 blocks before 2019-03-10 05:19:01 +0000 UTC
2019/03/10 09:19:35 ChainFetch: getTransactionDetail cannot get receipt for transaction 0x86ddf2be0f8fd35d447b55912fa1344ee16a41bbadcf7dd5af46aa06ef360c18, index=8, blockHash=0x2883380e724ac8b66a32a2215087fd5a83ebbda30562c4369ba5b111d2ac7407 error=not found
2019/03/10 09:19:35 ChainFetch: RealtimeFetch Cannot get block detail for block 7340581
2019/03/10 09:19:35 ChainFetch: Stopped RealtimeFetch
2019/03/10 09:19:35 Indexer: Stopping realtimeIndex, ipc is switched?
2019/03/10 09:19:35 Indexer: Stopped realtimeIndex
2019/03/10 09:19:35 IpcManager: Cannot switch IPC, number of IPC = 1
```

+ From the above log, we see that either the index or the transaction hash is not correct. Block number and block hash are right, they go with the transaction hash.