### PR TITLE
Fix npe in processRealtimeBlock

### DIFF
--- a/indexer/indexer.go
+++ b/indexer/indexer.go
@@ -225,7 +225,7 @@ func (indexer *Indexer) processRealtimeBlock(blockDetail *types.BLockDetail) {
 		return
 	}
 	var block *types.BLockDetail
-	blockNumber := block.BlockNumber
+	blockNumber := blockDetail.BlockNumber
 	for i := 0; i < 3; i++ {
 		log.Printf("Waiting for 1 more minute to get receipts for block %v . Try %v time \n", blockNumber.String(), i)
 		time.Sleep(1 * time.Minute)


### PR DESCRIPTION
## Goal:
+ Fix this error in processRealtimeBlock
```
b8a696fa4cd8e102afa01c594da61275579c7a, index=32, blockHash=0xfcb17d7b5f03c6b22af8d2e3bc2a7a3249b35b19cf626710c4c3caa55f6e3e4d error=not found
2019/03/16 13:53:19 ChainFetch: getTransactionDetailWG cannot get receipt for transaction 0x654e97278f512687f7755257e07f701b2e6414f64b89f8c6da5cb8b302aca4ab, index=33, blockHash=0xfcb17d7b5f03c6b22af8d2e3bc2a7a3249b35b19cf626710c4c3caa55f6e3e4d error=not found
2019/03/16 13:53:19 ChainFetch: getTransactionDetailWG cannot get receipt for transaction 0xfa9e780e68cbb6e06ed6929acafec4a92b28d11f031405cf0ed0507b829d92af, index=34, blockHash=0xfcb17d7b5f03c6b22af8d2e3bc2a7a3249b35b19cf626710c4c3caa55f6e3e4d error=not found
2019/03/16 13:53:19 ChainFetch: getTransactionDetailWG cannot get receipt for transaction 0x489f0f02a8d5a1a70e297de31d6a3a7c6a115a2af768b798a33054228fbb8206, index=36, blockHash=0xfcb17d7b5f03c6b22af8d2e3bc2a7a3249b35b19cf626710c4c3caa55f6e3e4d error=not found
2019/03/16 13:53:19 ChainFetch: getTransactionDetailWG cannot get receipt for transaction 0x5ccdf113dbc8781eff5089bed91ebb8706165f27e4bddcecbc266e7e648581ef, index=37, blockHash=0xfcb17d7b5f03c6b22af8d2e3bc2a7a3249b35b19cf626710c4c3caa55f6e3e4d error=not found
2019/03/16 13:53:19 Indexer: realtimeIndex - received BlockDetail 7380441 blockTime: 2019-03-16 13:53:13 +0000 UTC
2019/03/16 13:53:19 Indexer: block 7380441 has traansaction 0xb024e9d20a21bf9d09400ba82280e398745128013ebe1e4a4239bed6fa0cbb66 without receipt
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x77d7e0]

goroutine 2199166 [running]:
github.com/WeTrustPlatform/account-indexer/indexer.(*Indexer).processRealtimeBlock(0xc0007e62d0, 0xc0018275c0)
        /home/blockform/go/src/github.com/WeTrustPlatform/account-indexer/indexer/indexer.go:228 +0x50
github.com/WeTrustPlatform/account-indexer/indexer.(*Indexer).realtimeIndex.func1(0xc0007e62d0, 0xc0018275c0)
        /home/blockform/go/src/github.com/WeTrustPlatform/account-indexer/indexer/indexer.go:169 +0x35
created by github.com/WeTrustPlatform/account-indexer/indexer.(*Indexer).realtimeIndex
        /home/blockform/go/src/github.com/WeTrustPlatform/account-indexer/indexer/indexer.go:168 +0x210
blockform@mainindex2:~/go/src/github.com/WeTrustPlatform/account-indexer/cmd/indexer$
```