### PR TITLE
Fix version in cmd

### DIFF
--- a/cmd/indexer/main.go
+++ b/cmd/indexer/main.go
@@ -18,7 +18,6 @@ import (
 	"github.com/WeTrustPlatform/account-indexer/http"
 	"github.com/WeTrustPlatform/account-indexer/repository/keyvalue"
 	"github.com/ethereum/go-ethereum/console"
-	"github.com/ethereum/go-ethereum/params"
 	"github.com/syndtr/goleveldb/leveldb"
 
 	"os"
@@ -89,7 +88,7 @@ func newApp() *cli.App {
 	app.Author = ""
 	//app.Authors = nil
 	app.Email = ""
-	app.Version = params.VersionWithMeta
+	app.Version = config.GetVersion().Version
 	app.Usage = "the indexer for geth"
 	return app
 }


### PR DESCRIPTION
## Goal
+ Close #23
## Test in local env:
```
Tuyens-MacBook-Pro:account-indexer tuyennguyen$ go run cmd/indexer/main.go help
NAME:
   indexer - the indexer for geth

USAGE:
   main [global options] command [command options] [arguments...]

VERSION:
   1.0.3-alpha

COMMANDS:
     help, h  Shows a list of commands or help for one command
```